### PR TITLE
Depend on org-ql, since it includes helm-org-ql

### DIFF
--- a/org-linker.el
+++ b/org-linker.el
@@ -4,7 +4,7 @@
 
 ;; Author: tosh <tosh.lyons@gmail.com>
 ;; Version: 0.1
-;; Package-Requires: (org helm-org-ql)
+;; Package-Requires: (org org-ql)
 ;; URL: https://github.com/toshism/org-linker
 ;; Keywords: convenience, hypermedia
 


### PR DESCRIPTION
During installation, I've encountered the following error:

> Could not find package helm-org-ql in recipe repos (org-elpa melpa gnu-elpa-mirror emacsmirror-mirror).

There is no `helm-org-ql` package on MELPA. There only is `org-ql`, and it includes `helm-org-ql`.