### PR TITLE
Minor rewrite to avoid globally updating helm-org-ql-actions

### DIFF
--- a/org-linker.el
+++ b/org-linker.el
@@ -4,7 +4,7 @@
 
 ;; Author: tosh <tosh.lyons@gmail.com>
 ;; Version: 0.1
-;; Package-Requires: (org org-ql helm)
+;; Package-Requires: (org org-ql helm-org)
 ;; URL: https://github.com/toshism/org-linker
 ;; Keywords: convenience, hypermedia
 

--- a/org-linker.el
+++ b/org-linker.el
@@ -32,7 +32,10 @@
 (require 'helm-org-ql)
 
 (defgroup org-linker nil
-  "FIXME: Link things in orgmode")
+  "Link things in Org mode"
+  :group 'outlines
+  :group 'convenience
+  :group 'org)
 
 ;; Silence byte compiler
 (declare-function helm "ext:helm")

--- a/org-linker.el
+++ b/org-linker.el
@@ -4,7 +4,7 @@
 
 ;; Author: tosh <tosh.lyons@gmail.com>
 ;; Version: 0.1
-;; Package-Requires: (org org-ql helm-org)
+;; Package-Requires: ((emacs "24.1") org org-ql helm-org)
 ;; URL: https://github.com/toshism/org-linker
 ;; Keywords: convenience, hypermedia
 

--- a/org-linker.el
+++ b/org-linker.el
@@ -38,6 +38,8 @@
 ;; Silence byte compiler
 (declare-function helm "ext:helm")
 (declare-function helm-org-ql-source "ext:helm-org-ql")
+(declare-function org-agenda-files "ext:org")
+(declare-function org-back-to-heading "ext:org")
 (defvar helm-input-idle-delay)
 (defvar helm-org-ql-input-idle-delay)
 

--- a/org-linker.el
+++ b/org-linker.el
@@ -99,6 +99,7 @@ Call the user callback with target marker (M) and source marker."
       (funcall callback source target))))
 
 
+;;;###autoload
 (defun org-linker (callback)
   "Call CALLBACK function with two markers.
 CALLBACK should be a function that accepts two arguments SOURCE and

--- a/org-linker.el
+++ b/org-linker.el
@@ -82,7 +82,6 @@ Call CALLBACK with a marker to target heading."
          (helm-input-idle-delay helm-org-ql-input-idle-delay)
          (source (helm-org-ql-source (org-linker-get-search-buffers)
                                      :name "org-linker target")))
-    ;; You'll need a better action name here
     (setcdr (assoc 'action source) callback)
     (helm :prompt (format "Query (boolean %s): " (upcase (symbol-name boolean)))
           :sources source)))

--- a/org-linker.el
+++ b/org-linker.el
@@ -29,8 +29,6 @@
 
 ;;; Code:
 
-(require 'helm-org-ql)
-
 (defgroup org-linker nil
   "Link things in Org mode"
   :group 'outlines
@@ -77,6 +75,7 @@ the list."
 (defun org-linker-search-interface (callback)
   "Setup the helm-org-ql search interface.
 Call CALLBACK with a marker to target heading."
+  (require 'helm-org-ql)
   (let* ((boolean 'and)
          (helm-input-idle-delay helm-org-ql-input-idle-delay)
          (source (helm-org-ql-source (org-linker-get-search-buffers)

--- a/org-linker.el
+++ b/org-linker.el
@@ -4,7 +4,7 @@
 
 ;; Author: tosh <tosh.lyons@gmail.com>
 ;; Version: 0.1
-;; Package-Requires: (org helm-org-ql)
+;; Package-Requires: (org org-ql helm)
 ;; URL: https://github.com/toshism/org-linker
 ;; Keywords: convenience, hypermedia
 
@@ -33,6 +33,12 @@
 
 (defgroup org-linker nil
   "FIXME: Link things in orgmode")
+
+;; Silence byte compiler
+(declare-function helm "ext:helm")
+(declare-function helm-org-ql-source "ext:helm-org-ql")
+(defvar helm-input-idle-delay)
+(defvar helm-org-ql-input-idle-delay)
 
 (defvar org-linker-to-heading nil)
 
@@ -68,10 +74,14 @@ the list."
 (defun org-linker-search-interface (callback)
   "Setup the helm-org-ql search interface.
 Call CALLBACK with a marker to target heading."
-  (add-to-list 'helm-org-ql-actions (cons "super-link-temp" callback) nil)
-  (helm-org-ql (org-linker-get-search-buffers))
-  (pop helm-org-ql-actions))
-
+  (let* ((boolean 'and)
+         (helm-input-idle-delay helm-org-ql-input-idle-delay)
+         (source (helm-org-ql-source (org-linker-get-search-buffers)
+                                     :name "org-linker target")))
+    ;; You'll need a better action name here
+    (setcdr (assoc 'action source) callback)
+    (helm :prompt (format "Query (boolean %s): " (upcase (symbol-name boolean)))
+          :sources source)))
 
 (defun org-linker-callback-wrapper (callback m)
   "Call user provided CALLBACK with source marker and target marker M.


### PR DESCRIPTION
I don't like the idea of destructively updating global variables like `helm-org-ql-actions` and then rolling it back. For example, helm has a feature of resuming the previous session, where the current implementation wouldn't work as expected.

Instead, I'd suggest copying and pasting the implementation of `helm-org-ql` function and setting the action of the source.

P.S. I reached this package via Karl Voit's blog post on using `org-edna`. Sorry for missing the PR description at first.